### PR TITLE
chore: Update commons-io version to 2.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.19.0</version>
+            <version>2.20.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Eliminate: CVE-2022-42889