### PR TITLE
chore: Remove commons-io dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,6 @@
             ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}
         </osgi.bundle.version>
     </properties>
-    <dependencies>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.20.0</version>
-        </dependency>
-    </dependencies>
 
     <build>
         <plugins>

--- a/src/main/java/com/vaadin/open/FileUtil.java
+++ b/src/main/java/com/vaadin/open/FileUtil.java
@@ -5,24 +5,39 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.IOUtils;
 
 public class FileUtil {
 
     public static String readFile(File file) throws IOException {
         try (FileInputStream in = new FileInputStream(file)) {
-            return IOUtils.toString(in, StandardCharsets.UTF_8);
+            return toString(in);
         }
     }
 
     public static String read(InputStream inputStream) throws IOException {
-        return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        return toString(inputStream);
     }
 
     public static void copy(InputStream in, FileOutputStream out) throws IOException {
-        IOUtils.copy(in, out);
+        byte[] buffer = new byte[8192];
+        int bytesRead;
+        while ((bytesRead = in.read(buffer)) != -1) {
+            out.write(buffer, 0, bytesRead);
+        }
+    }
+
+    private static String toString(InputStream inputStream) throws IOException {
+        StringBuilder result = new StringBuilder();
+        try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            char[] buffer = new char[8192];
+            int charsRead;
+            while ((charsRead = reader.read(buffer)) != -1) {
+                result.append(buffer, 0, charsRead);
+            }
+        }
+        return result.toString();
     }
 
 }


### PR DESCRIPTION
Replace commons-io IOUtils with Java 8 standard library implementations in FileUtil.java. The dependency was only used for reading InputStreams to Strings and copying streams, which can be efficiently handled with InputStreamReader and manual buffering.
